### PR TITLE
GGRC-5129 WF admin is not able to remove secondary assignee via import

### DIFF
--- a/src/ggrc/converters/handlers/acl.py
+++ b/src/ggrc/converters/handlers/acl.py
@@ -40,15 +40,18 @@ class AccessControlRoleColumnHandler(handlers.UsersColumnHandler):
 
   def set_obj_attr(self):
     """Update current AC list with correct people values."""
-    if not self.value:
+    value_is_correct = self.value or self.set_empty
+    if not value_is_correct:
       return
     list_old = {
         acl.person
         for acl in self.row_converter.obj.access_control_list
         if acl.ac_role == self.role
     }
+    if self.set_empty:
+      self._remove_people(list_old)
+      return
     list_new = set(self.value)
-
     self._add_people(list_new - list_old)
     self._remove_people(list_old - list_new)
 

--- a/src/ggrc/converters/handlers/handlers.py
+++ b/src/ggrc/converters/handlers/handlers.py
@@ -273,8 +273,20 @@ class UserColumnHandler(ColumnHandler):
 class UsersColumnHandler(UserColumnHandler):
   """Handler for multi user fields."""
 
+  def _missed_mandatory_person(self):
+    """Create response for missing mandatory field"""
+    self.add_warning(errors.OWNER_MISSING, column_name=self.display_name)
+    return [get_current_user()]
+
   def parse_item(self):
+    """Parses multi users field."""
     people = set()
+    if self.raw_value in {"-", "--", "---"}:
+      if not self.mandatory:
+        self.set_empty = True
+        return None
+      return self._missed_mandatory_person()
+
     email_lines = self.raw_value.splitlines()
     owner_emails = filter(unicode.strip, email_lines)  # noqa
     for raw_line in owner_emails:
@@ -286,8 +298,7 @@ class UsersColumnHandler(UserColumnHandler):
         self.add_warning(errors.UNKNOWN_USER_WARNING, email=email)
 
     if not people and self.mandatory:
-      self.add_warning(errors.OWNER_MISSING, column_name=self.display_name)
-      people.add(get_current_user())
+      return self._missed_mandatory_person()
 
     return list(people)
 

--- a/test/integration/ggrc/access_control/test_access_control_role.py
+++ b/test/integration/ggrc/access_control/test_access_control_role.py
@@ -2,13 +2,24 @@
 # Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
 
 """Test Access Control Role"""
+from collections import OrderedDict, defaultdict
+
 import ddt
 
 from ggrc.access_control.role import AccessControlRole
+from ggrc.converters import errors
+from ggrc.models import all_models
 from integration.ggrc import TestCase
 from integration.ggrc.api_helper import Api
 from integration.ggrc.models.factories import random_str
+from integration.ggrc.models import factories
 from integration.ggrc.generator import ObjectGenerator
+
+ROLE_NAME = "ACR for mandatory test"
+MANDATORY_ROLE_RESPONSE = {
+    "Control": {"row_warnings": {errors.OWNER_MISSING.format(
+        line=3, column_name=ROLE_NAME)}}}
+NON_MANDATORY_ROLE_RESPONSE = {}
 
 
 @ddt.ddt
@@ -53,6 +64,37 @@ class TestAccessControlRole(TestCase):
         "Update permission not correctly saved {}".format(role.update)
     assert role.delete == 1, \
         "Update permission not correctly saved {}".format(role.delete)
+
+  @ddt.data({"mandatory": True, "exp_response": MANDATORY_ROLE_RESPONSE},
+            {"mandatory": False, "exp_response": NON_MANDATORY_ROLE_RESPONSE})
+  @ddt.unpack
+  def test_mandatory_delete(self, mandatory, exp_response):
+    """Test set empty field via import if acr mandatory is {mandatory}"""
+    with factories.single_commit():
+      user = factories.PersonFactory()
+      control = factories.ControlFactory()
+      role = factories.AccessControlRoleFactory(name=ROLE_NAME,
+                                                object_type="Control",
+                                                mandatory=mandatory)
+      role_id = role.id
+      factories.AccessControlListFactory(person=user,
+                                         ac_role_id=role.id,
+                                         object=control)
+    response = self.import_data(OrderedDict([
+        ("object_type", "Control"),
+        ("Code*", control.slug),
+        (ROLE_NAME, "--"),
+    ]))
+    self._check_csv_response(response, exp_response)
+    db_data = defaultdict(set)
+    for acl in all_models.Control.query.get(control.id).access_control_list:
+      db_data[acl.ac_role_id].add(acl.person_id)
+    if mandatory:
+      cur_user = all_models.Person.query.filter_by(
+          email="user@example.com").first()
+      self.assertEqual(set([cur_user.id]), db_data[role_id])
+    else:
+      self.assertFalse(db_data[role_id])
 
   def test_only_admin_can_post(self):
     """Only admin users should be able to POST access control roles"""


### PR DESCRIPTION
<!-- If your PR depends on other tickets or PRs, you can list them here
# Dependencies

This PR is `on hold` until the dependencies are merged:

- [ ] GGRC-1234
- [ ] #1234
-->

# Issue description

Logged WF admin user can't delete Task Secondary Assignee using "--" key in imported Google sheet. 

# Steps to test the changes
Steps to reproduce:
1. Log as Admin user and create any WF (Need verification - TRUE)
2. In the Setup tab create a task for task group with filled Task Secondary Assignee
3. Activate WF
4. Export Cycle Task to Google Sheet or csv file
5. Remove Task Secondary Assignee from Cycle Task in Google Sheet or csv using "--"
6. Import Cycle Task
7. In Active Cycles tab open Cycle Task Info panel and look at the Task Secondary Assignee

Expected Result: Task Secondary Assignee's were deleted. 

# Solution description

I've added to multi users fields handler checks  to set "set_empty" flag for non-mandatory fields and to clear them in AC "set_obj_attr" method

# Sanity checklist

- [x] I have clicked through the app to make sure my changes work and not break the app.
- [ ] I have applied the correct milestone and labels.
- [ ] My changes fix the issue described in the description (and do nothing else). 🤞
- [x] My changes are covered by tests.
- [x] My changes follow our [performance guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/performance.rst).
- [x] My changes follow our [js](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/javascript.rst) and/or [python](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/python.rst) guidelines.
- [x] My commits follow our [commit guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/how_to_write_a_commit_message.rst).

<!-- If your PR includes a migration include the additional checklist items
# Migration checklist
- [ ] Migration passes all checks from our [PR review guidelines](https://github.com/google/ggrc-core/blob/dev/docs/source/contributing/git/reviewing_pull_requests.rst#reviewing-a-pr-containing-database-migration-scripts)
-->

# PR Review checklist

- [ ] The changes fix the issue and don't cause any apparent regressions.
- [ ] Labels and milestone are correctly set.
- [ ] The solution description matches the changes in the code.
- [ ] There is no apparent way to improve the performance & design of the new code.
- [ ] The pull request is opened against the correct base branch.
- [ ] Upon merging, the Jira ticket's fixversion is correctly set and the ticket is moved to "QA - In Progress".

# TODO

- [x] Make tests
- [ ] I thing it would be good to create ticket to refactor handlers to improve code reusage for such kind of functionality
